### PR TITLE
fix: Add missing <id> tag to assembly.xml to fix build failure

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -2,7 +2,8 @@
    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
-
+  
+  <id>package</id> 
   <baseDirectory>${project.artifactId}</baseDirectory>
   
   <formats>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added the `<id>` tag with value "package" to the `assembly.xml`. This resolves the build failure that occurred due to the missing assembly identifier.

## Why are these changes needed?

- The Maven build was failing because the assembly descriptor lacked a mandatory `<id>` element, which is required for the Maven Assembly Plugin to execute properly. This change fixes the build process by correctly configuring the assembly descriptor.

## What are the side effects of this change?

- This change only affects the Maven assembly configuration and should not impact other parts of the project.

## References

- [Maven Assembly Plugin Documentation](http://maven.apache.org/plugins/maven-assembly-plugin/)
- Issue tracker link or ID (if applicable)

